### PR TITLE
perf: stop battle-only renderer state from accumulating without bound

### DIFF
--- a/native_renderer/src/infrastructure/xg_render_submission.c
+++ b/native_renderer/src/infrastructure/xg_render_submission.c
@@ -20,6 +20,21 @@ static bool submission_services_configured;
 static XgRenderSubmissionObserver submission_observer;
 static void *submission_observer_user_data;
 
+/* Each standalone scene gets a fresh scene_epoch, so the stream's own
+ * same-epoch supersede logic never retires the previous one. Track it
+ * ourselves and abandon it once its successor is active. */
+static GpuRenderTransactionId last_activated_standalone_visual;
+
+static void retire_previous_standalone_visual(GpuRenderTransactionId visual) {
+    if (last_activated_standalone_visual.scene_epoch != 0u &&
+        !(last_activated_standalone_visual.scene_epoch == visual.scene_epoch &&
+          last_activated_standalone_visual.state_sequence ==
+              visual.state_sequence))
+        guest_render_native_stream_abandon_visual(
+            last_activated_standalone_visual);
+    last_activated_standalone_visual = visual;
+}
+
 static uint64_t interpolation_generation(void) {
     return submission_services_configured &&
             submission_services.interpolation_generation != NULL
@@ -431,11 +446,14 @@ bool xg_render_submission_standalone_finalize(void) {
             guest_render_native_stream_has_staged_predecessor(
                 (GpuRenderTransactionId){
                     completed.id.scene_epoch, completed.id.state_sequence,
-                }))
-            (void)guest_render_native_stream_activate_visual(
-                (GpuRenderTransactionId){
-                    completed.id.scene_epoch, completed.id.state_sequence,
-                });
+                })) {
+            const GpuRenderTransactionId visual_id = {
+                completed.id.scene_epoch, completed.id.state_sequence,
+            };
+            if (guest_render_native_stream_activate_visual(visual_id) ==
+                    GUEST_RENDER_NATIVE_STREAM_OK)
+                retire_previous_standalone_visual(visual_id);
+        }
         return true;
     }
     if (guest_render_bridge_producer_end(
@@ -453,13 +471,16 @@ bool xg_render_submission_standalone_finalize(void) {
         xg_render_submission_standalone_abort();
         return true;
     }
-    if (guest_render_native_stream_enabled() &&
-        guest_render_native_stream_activate_visual(
-            (GpuRenderTransactionId){
-                completed.id.scene_epoch, completed.id.state_sequence,
-            }) != GUEST_RENDER_NATIVE_STREAM_OK) {
-        xg_render_submission_standalone_abort();
-        return false;
+    if (guest_render_native_stream_enabled()) {
+        const GpuRenderTransactionId visual_id = {
+            completed.id.scene_epoch, completed.id.state_sequence,
+        };
+        if (guest_render_native_stream_activate_visual(visual_id) !=
+                GUEST_RENDER_NATIVE_STREAM_OK) {
+            xg_render_submission_standalone_abort();
+            return false;
+        }
+        retire_previous_standalone_visual(visual_id);
     }
     clear_standalone();
     return true;
@@ -601,6 +622,7 @@ void xg_render_submission_reset(void) {
     clear_standalone();
     standalone_stage_failure_detail = 0u;
     xg_render_temporal_submission_reset();
+    last_activated_standalone_visual = (GpuRenderTransactionId){0};
 }
 
 void xg_render_submission_reset_transaction(void) {
@@ -655,6 +677,7 @@ void xg_render_submission_scene_boundary(void) {
     xg_render_submission_reset_transaction();
     xg_render_submission_pre_scene_clear();
     xg_render_submission_standalone_abort();
+    last_activated_standalone_visual = (GpuRenderTransactionId){0};
 }
 
 void xg_render_submission_source_reset(void) {

--- a/native_renderer/src/producers/field/xg_render_field_sprite.c
+++ b/native_renderer/src/producers/field/xg_render_field_sprite.c
@@ -917,8 +917,10 @@ void xg_render_field_sprite_handle_invalidation(
         xg_render_field_sprite_clear_builder(services->field_sprite);
         xg_render_field_sprite_clear_templates(services->field_sprite);
     } else if (event->kind == XG_RENDER_INVALIDATION_SCENE_BOUNDARY) {
+        /* Full clear, not retain-resident: a field<->battle transition
+         * must not let templates survive across it. */
         xg_render_field_sprite_clear_builder(services->field_sprite);
-        xg_render_field_sprite_retain_resident(services->field_sprite);
+        xg_render_field_sprite_clear_templates(services->field_sprite);
     } else if (event->kind == XG_RENDER_INVALIDATION_LOADER_MISMATCH ||
                event->kind == XG_RENDER_INVALIDATION_RESOURCE_OVERLAP) {
         xg_render_field_sprite_retain_resident(services->field_sprite);

--- a/native_renderer/src/producers/field/xg_render_residual.c
+++ b/native_renderer/src/producers/field/xg_render_residual.c
@@ -211,8 +211,11 @@ void xg_render_residual_handle_invalidation(
     } else if (event->kind == XG_RENDER_INVALIDATION_DISABLE ||
                event->kind == XG_RENDER_INVALIDATION_RESET) {
         xg_render_residual_reset();
-    } else if (event->kind == XG_RENDER_INVALIDATION_SCENE_BOUNDARY ||
-               event->kind == XG_RENDER_INVALIDATION_LOADER_MISMATCH ||
+    } else if (event->kind == XG_RENDER_INVALIDATION_SCENE_BOUNDARY) {
+        /* Full clear, not retain-resident: a field<->battle transition
+         * must not let templates survive across it. */
+        xg_render_residual_reset();
+    } else if (event->kind == XG_RENDER_INVALIDATION_LOADER_MISMATCH ||
                event->kind == XG_RENDER_INVALIDATION_RESOURCE_OVERLAP) {
         xg_render_residual_retain_resident();
     }

--- a/native_renderer/src/producers/model/xg_render_model_repository.c
+++ b/native_renderer/src/producers/model/xg_render_model_repository.c
@@ -964,8 +964,13 @@ void xg_render_model_repository_handle_invalidation(
         xg_render_model_repository_clear_ft4_sources();
         xg_render_model_repository_clear_ft3_sources(
             services->model_repository);
-    } else if (event->kind == XG_RENDER_INVALIDATION_SCENE_BOUNDARY ||
-               event->kind == XG_RENDER_INVALIDATION_LOADER_MISMATCH ||
+    } else if (event->kind == XG_RENDER_INVALIDATION_SCENE_BOUNDARY) {
+        /* Full clear, not retain-resident: a field<->battle transition
+         * must not let FT3/FT4 sources survive across it. */
+        xg_render_model_repository_clear_ft4_sources();
+        xg_render_model_repository_clear_ft3_sources(
+            services->model_repository);
+    } else if (event->kind == XG_RENDER_INVALIDATION_LOADER_MISMATCH ||
                event->kind == XG_RENDER_INVALIDATION_RESOURCE_OVERLAP) {
         xg_render_model_repository_retain_resident_sources(
             services->model_repository);


### PR DESCRIPTION
## Summary
- Battle no longer shares the field renderer's per-frame full clear, so
  several render-side caches only ever reset at a field<->battle
  transition -- never mid-battle. Two separate gaps, same symptom:
  - Model FT3/FT4 sources, field sprite templates, and residual templates
    retained their resident state across a battle transition instead of
    clearing (first commit).
  - The render stream's active-visual table had no reset at all during a
    battle and grew by roughly one entry per frame for the whole fight,
    with per-draw lookup cost scaling with table size -- the actual
    driver of the progressive in-battle slowdown (second commit).
- Field/world/menu rendering is unaffected; both fixes are scoped to the
  battle-only code paths.