### PR TITLE
docs: document Battling AI, index its RNG, and add a Characters chapter

### DIFF
--- a/docs/xenogears/battling/06-ai-practice-and-rubber-band.md
+++ b/docs/xenogears/battling/06-ai-practice-and-rubber-band.md
@@ -207,8 +207,24 @@ changes, it becomes true only across signed 16-bit wraparound.
 
 ### 5.3 Attack state
 
-Attack entry queues an initial basic burst and chooses the difficulty-dependent
-repetition count. It clears movement and boost and refreshes tactical flags.
+Attack entry queues an initial basic burst through
+`BattlingAiRandomBasicBurstQueue` at `0x8008FE80` and chooses the
+difficulty-dependent repetition count. It clears movement and boost and
+refreshes tactical flags. The burst queue itself is:
+
+```text
+residue = random(0..9)
+count   = 1 if residue < 2   (20%)
+        = 2 if residue < 5   (30%, else)
+        = 3 otherwise        (50%)
+repeat count times:
+    action = random(0..1) + 1   /* command 1 or 2, uniform */
+    enqueue action
+```
+
+The same helper backs `BattlingAiBasicBurstRefresh` (§4) and the practice
+"UP AND AT'EM"/"SLOWPOKE" behaviors (§8), which call it through
+`BattlingPracticeRandomBasicActionsQueue` at `0x8008EF30`.
 
 `BattlingAiAttackSequenceChoose` at `0x80090258` selects between an ordinary
 burst and an available special. Specials can be selected while fighter
@@ -266,6 +282,38 @@ are `10..69` updates, or `10..49` with tactical flag `0x0400`. The state returns
 to Idle after passing its target distance, or immediately when three-dimensional
 fighter separation exceeds `0x4B0` while rubber-band mode is active. At close range it
 can face `-0x400` or `+0x400`, request boost, and queue evasive bursts.
+
+### 5.6 Terrain-dependent action gate
+
+`BattlingAiQueueTerrainDependentActions` at `0x8008F900` is a shared helper
+called from Idle update, Approach update, Retreat update (twice), and both
+`BattlingAiBasicBurstRefresh` and `BattlingAiAttackSequenceChoose` — anywhere
+the machine is about to queue jump or special-action commands. Fighter flags
+word `+0xD0` packs a two-bit terrain class at bits `0x60000000`; class `1`
+(`0x20000000`) marks a fighter standing on the arena's raised/special terrain.
+
+```text
+if opponent.flags & 0x60000000 == 0x20000000:      /* opponent on terrain class 1 */
+    if random(0..3) != 0:                          /* 75% of the time */
+        return                                      /* suppress the whole call */
+    /* else (25%) fall through */
+
+if rubber_band_mode:
+    BattlingQueueCloseRangeReaction(self)            /* 0x800767C8, side effect only */
+    enqueue command 4 (jump)
+elif self.flags & 0x60000000 == 0x20000000:          /* self on terrain class 1 */
+    enqueue command 4 (jump)
+
+enqueue command 3 (special action)                   /* always, once suppression clears */
+```
+
+So an opponent standing on terrain class 1 gives the AI only a 1-in-4 chance
+per call to act at all; when it does act (or the opponent isn't on that
+terrain), a jump is queued whenever rubber-band mode is active or the AI's
+own fighter is on terrain class 1, and a special-action command is queued
+unconditionally afterward. Both queue writes go through
+`BattlingEnqueueFighterCommand` at `0x8007639C`, the same 32-entry circular
+command queue used elsewhere in this chapter.
 
 ## 6. Attack Approval Probabilities
 
@@ -341,6 +389,38 @@ The dispatcher briefly writes `0`, `1`, or `2` for these three labels, but
 The movement and queued-action behaviors call `BattlingAiSteeringApply` after
 updating desired heading and speed, so they use the same acceleration and
 turning rules as normal COM control.
+
+### 8.1 GIVE CHASE and RUN AWAY
+
+`BattlingPracticeFarRangeMovementUpdate` (`0x8008F17C`, GIVE CHASE) and
+`BattlingPracticeNearRangeMovementUpdate` (`0x8008F094`, RUN AWAY) share one
+structure, reading and writing a small movement sub-state reached through the
+fighter's practice pointer rather than its ordinary `+0x48`/`+0x58` request
+fields directly:
+
+```text
+if GIVE CHASE and horizontal_distance < 0x100:   stop (park the behavior)
+if RUN AWAY   and horizontal_distance >= 0x801:  stop (park the behavior)
+
+countdown -= 1
+if countdown != -1: continue parked/moving as-is
+
+# countdown expired: pick a new heading and a new countdown
+heading   = GIVE CHASE: (random(0..1535) - 768)    # range -768..767, biased toward 0
+          = RUN AWAY:   (random(0..1535) + 1280)   # range 1280..2815, biased toward 2048
+speed     = 0xFF (full)
+countdown = GIVE CHASE: random(0..119) + 10         # 10..129 updates
+          = RUN AWAY:   random(0..49)  + 10         # 10..59 updates
+```
+
+The two heading ranges are both 1536 units wide and sit exactly 2048 apart —
+consistent with a 12-bit (`0x1000`-per-turn) angle unit, GIVE CHASE biased
+toward "face the opponent" and RUN AWAY toward the opposite direction. This
+chapter did not trace the code that consumes that stored heading and writes
+the fighter's actual movement-request fields, so the angle unit and sign
+convention are inferred from the numeric symmetry, not independently
+confirmed. RUN AWAY re-rolls its heading roughly twice as often as GIVE CHASE
+(10-59 versus 10-129 updates).
 
 ## 9. Rubber-Band Mechanics
 

--- a/docs/xenogears/battling/08-tutorial-and-attract-scripts.md
+++ b/docs/xenogears/battling/08-tutorial-and-attract-scripts.md
@@ -118,11 +118,19 @@ operations retain their program counter while moving:
 |---:|---|---:|---:|
 | `0B` | `horizontal_distance > 0xFF` | `0xF0` | `0` |
 | `0C` | `horizontal_distance <= 0x400` | `0xF0` | `0x800` |
-| `0D` | fighter needs arena reentry, or `horizontal_distance <= 0x800` | maximum/reentry | randomized inward heading, then `0x800` |
+| `0D` | fighter needs arena reentry, or `horizontal_distance <= 0x800` | maximum/reentry | computed inward heading (not randomized, see below), then `0x800` |
 
-`BattlingStartRandomArenaReentryMotion` at `0x80070FD8` chooses one of two
-inward headings, sets maximum-speed recovery movement, and resets the animation
-phase before opcode `0D` resumes its distance test.
+`BattlingStartRandomArenaReentryMotion` at `0x80070FD8` picks between two
+*computed* inward headings, sets maximum-speed recovery movement, and resets
+the animation phase before opcode `0D` resumes its distance test. Despite its
+name, the function contains no random roll: it calls `ratan2` (PsyQ libgte,
+`0x8004B32C`) toward the arena center and, only when that result falls below
+a small threshold (an edge case near a particular facing), substitutes a
+fixed fallback angle instead of the shared side-to-side heading global
+(`0x80092934`, see [`06`](06-ai-practice-and-rubber-band.md#2-fighter-fields-used-by-ai)).
+The exact final combination of the two candidate angles was not traced in
+full; what's confirmed is that no call in this function reaches the shared
+`rand` generator or any of its wrappers.
 
 ## 5. Fighter Action And Control Operations
 

--- a/docs/xenogears/characters/01-characters.md
+++ b/docs/xenogears/characters/01-characters.md
@@ -1,0 +1,352 @@
+# Characters
+
+## 1. Scope
+
+This chapter assembles what's already documented, elsewhere, about the eleven
+playable characters into one place: who they are, how their stats are stored
+and recalculated, how they gain experience and level up, how they unlock
+deathblows and abilities, the three characters with genuinely different rules,
+and how a character's state persists across Battle. Every formula here is
+quoted from the chapter that actually derives it, not re-derived — this
+document exists to connect facts that live in `battle/03`, `battle/05`,
+`battle/08`, and `menu/06`/`menu/08`, which were written module-by-module and
+never cross-indexed by character before now.
+
+## 2. The Eleven-Character Roster
+
+Character IDs, names, and internal aliases come from
+`debug_overlay/data/characters.xml`. ID doubles as the persistent character
+record index used throughout Battle and Menu.
+
+| ID | Name | Internal alias | Notes |
+|---:|---|---|---|
+| 0 | Fei | Fei | |
+| 1 | Elly | Elly | |
+| 2 | Citan | Shitan | |
+| 3 | Bart | Baltho | |
+| 4 | Billy | Billy | Command-loadout type 4; see [§8](#8-character-specific-exceptions) |
+| 5 | Rico | Lico | |
+| 6 | Emeralda | Emerada | |
+| 7 | Chu-Chu | Chuchu | Character ID 7; see [§8](#8-character-specific-exceptions) |
+| 8 | Maria | Maria | Command-loadout type 8; see [§8](#8-character-specific-exceptions) |
+| 9 | Citan (2) | Shitan2 | Distinct persistent record and command-loadout type from ID 2 |
+| 10 | Emeralda (2) | Emerada2 | Distinct persistent record and command-loadout type from ID 10 |
+
+The entity field at `+0x56` is documented in `battle/03`/`battle/08` as
+"character identity/command-loadout type," and two characters' own sections
+confirm the type number equals the character's own roster ID directly (Billy
+is ID 4 and is called "command-loadout type 4"; Maria is ID 8 and is called
+"command-loadout type 8"). No source chapter states this equivalence as a
+general rule, but the two confirmed cases line up exactly with roster ID, and
+nothing found contradicts it holding for the other nine — treat it as
+strongly supported, not independently re-derived here. "Citan (2)" and
+"Emeralda (2)" are separate roster slots (IDs 9 and 10) with their own
+persistent records and growth tables — likely used where the story briefly
+splits the party and needs an independent stat line for the same named
+character, but which specific story moments use them was not investigated.
+
+## 3. Stat Record Layout
+
+Every character occupies the same `0x170`-byte live Battle entity envelope
+documented in full in
+[`battle/03` §3](../battle/03-combatants-turns-and-targeting.md#3-entity-record).
+The character-relevant fields, gathered from that table:
+
+| Offset | Type | Meaning |
+|---:|---|---|
+| `0x3C` | `u32` | Cumulative Physical EXP |
+| `0x40` | `u32` | Cumulative Ether EXP |
+| `0x44` | `u32` | Physical EXP remaining to next level |
+| `0x48` | `u32` | Ether EXP remaining to next level |
+| `0x4C..0x53` | `u16[4]` | Current HP, maximum HP, current MP/EP, maximum MP/EP |
+| `0x54` | `u8` | Hyper Mode Points (Gear-side, see [§7](#7-attacks-deathblows-and-attack-level)) |
+| `0x55` | `u8` | Base deathblow-proficiency gain per qualifying attack |
+| `0x56` | `u8` | Character identity/command-loadout type |
+| `0x58..0x5C` | `u8[5]` | Attack, Defence, Agility, Ether, Ether Defence |
+| `0x5E..0x5F` | `u8[2]` | Hit and Evade percentages |
+| `0x62..0x63` | `u8[2]` | Physical Level and Ether Level |
+| `0x6A..0x76` | `u8[13]` | Weapon, loadout, and equipped non-weapon ID banks |
+| `0x7A` | `u16` | Enabled-command bitfield |
+| `0x90..0x9F` | `u16[8]` | Deathblow-proficiency counters (first seven used, see [§7](#7-attacks-deathblows-and-attack-level)) |
+| `0xA0` | `u8` | Associated Gear identifier; `0xFF` selects no Gear |
+| `0xA1` | `u8` | Equipment-derived deathblow-proficiency gain |
+
+Equipment layers on top of these base values rather than replacing them —
+the modifier fields (`0x28..0x32`, equipment-derived Attack/Defence/Agility/
+Ether/Ether Defence/Hit/Evade/HP/MP bonuses and effect flags) are also part
+of the same record; see `battle/03` §3 for their exact offsets, and §4 below
+for how they combine into what's actually displayed.
+
+## 4. Equipment And Displayed Stats
+
+`menu/06` §14.2 documents the two functions that turn base stats plus
+equipped items into what the player actually sees:
+
+- `RecalculateCharacterEquipmentEffects` (General Menu `0x801E36D4`) clears
+  accumulated equipment-derived state, then folds three equipped items into
+  attribute modifiers, status/elemental masks, weapon power/effect/attribute
+  fields, and accuracy/response-style modifiers.
+- `CalculateCharacterDisplayedStats` (General Menu `0x801E3A80`) combines base
+  character values, weapon values, and the accumulated equipment modifiers
+  into seven displayed values, capped at 250 for attack/defence/ether-style
+  values and 99 for hit/evade, with a special Agility correction above 20.
+
+These are derived display values — changing equipment re-runs the fold rather
+than patching a stored total. Full detail:
+[`menu/06` §14.2](../menu/06-general-menu-pages-and-gameplay.md#142-character-recalculation).
+
+## 5. Experience And Leveling
+
+Full derivation: [`battle/08` §5-7](../battle/08-results-progression-and-persistence.md#5-reward-eligibility-and-totals).
+
+Enemy EXP and gold accumulate from qualifying enemy slots after a win, then
+`BattleResultDistributeExperience` (`0x801E2ACC`) applies a signed
+quarter-step encounter modifier before splitting the total:
+
+| Recipient | Base share |
+|---|---:|
+| Active survivor | `floor(T / (3 - N))`, `T` = adjusted encounter EXP, `N` = absent/terminal active slots |
+| Benched roster member | `floor(3 * floor(T / 3) / 4)` |
+| Active terminal/removed member | `0` |
+
+Each recipient's share then splits into Physical and Ether EXP by that
+character's own weight bytes (live `+0x158`/`+0x159`, each floored to a
+minimum of 1):
+
+```text
+physical_gain = floor(share * physical_weight / (physical_weight + ether_weight))
+ether_gain    = floor(share * ether_weight    / (physical_weight + ether_weight))
+```
+
+A "standard progression" flag gives the full share to both tracks instead
+(coupled with a stored level cap of 99). Hercules Ring (+50% both tracks) and
+the Ether-EXP booster (+50% Ether only, applied after Hercules Ring) are
+equipment-effect flags on top of that. See `battle/08` §6 for the exact flag
+bits and ordering.
+
+`BattleResultApplyLevelUps` (`0x801E308C`) then processes each track
+independently against a shared per-level threshold table (`u32` at Result
+resource `+0xBAC + level * 4`), looping through every level crossed in one
+result (including multiple level-ups from one large award) and rolling one
+stat-growth pass per crossing. See `battle/08` §7 for the level-99/100
+boundary rules the "standard progression" flag also affects.
+
+## 6. Stat Growth
+
+Full derivation: [`battle/08` §8](../battle/08-results-progression-and-persistence.md#8-stat-growth).
+
+Physical Level growth (`0x801E335C`) updates maximum HP, Attack, Defence, Hit,
+and Evade. Ether Level growth (`0x801E3500`) updates maximum MP, Ether, and
+Ether Defence. Growth targets come from a per-command-loadout-type `0x110`-byte
+growth-table record (one target pair, below/above level 99, per stat) — the
+record's existence and offsets are documented, but the actual target values
+per character have not been extracted into a table here (see
+[§10](#10-not-yet-extracted-per-character-growth-targets-ability-costs-and-effects)).
+
+The roll formulas themselves (quoted, not re-derived):
+
+```text
+# One-byte stats (Attack, Defence, Hit, Evade, Ether, Ether Defence), next_level < 100
+score = trunc(((target - current) * 100) / (100 - next_level)) - 50 + random_mod_100
+if score >= 50: current += 1
+current = min(current, 200)
+
+# Maximum MP, next_level < 100
+score = trunc(((target_mp - max_mp) * 100) / (99 - next_level)) - 50 + random_mod_100
+if score >= 50: max_mp += 1
+max_mp = min(max_mp, 99)
+
+# Maximum HP, next_level < 100
+gain = trunc(random_mod_100 * (hp_target_1 + 99 - next_level - max_hp) / ((100 - next_level) * 100)) + 2
+max_hp = min(999, max_hp + max(gain, 0))
+```
+
+Levels 100+ use a second target byte and a `200 - next_level`-based
+denominator for all three formula families; see `battle/08` §8 for the exact
+post-99 variants. Every growth roll draws its own independent `rand()` call
+— indexed in [`rng/02-battle-rng.md` §7](../rng/02-battle-rng.md#7-results-progression-and-drops).
+
+## 7. Attacks, Deathblows, And Attack Level
+
+Gear-side Attack Level, the fifteen-slot attack index space, deathblow input
+sequences, and Hyper Mode Points are documented in full in
+[`battle/05` §5](../battle/05-gear-combat-and-special-commands.md#5-gear-attacks-levels-and-deathblows) —
+not repeated here.
+
+Deathblow proficiency and unlocks, from
+[`battle/08` §9](../battle/08-results-progression-and-persistence.md#9-deathblows-abilities-and-ap-level):
+
+- During a resolved character attack (party slot `0..2`, basic-attack index
+  `0..6`), `BattleComputeAttackResults` (`0x800941A4`) adds
+  `entity.byte_0x55 + entity.byte_0xA1` (base learning rate plus an active
+  modifier) to one of the first seven `+0x90` proficiency counters, capped
+  below `65000`.
+- `BattleResultUnlockPrimaryAbility` (`0x801E3BE0`) checks one locked
+  candidate at a time against an unlock bit, a Physical Level requirement,
+  and seven proficiency-counter requirements — seven candidates ordinarily,
+  thirteen when advanced deathblows are enabled globally
+  (`0x8006F8EA:0x4000`).
+- `BattleResultUnlockSecondaryAbility` (`0x801E3D54`) unlocks Ether abilities
+  by Ether Level against up to twelve threshold bytes.
+- `BattleResultUnlockHighLevelAbilities` (`0x801E41B4`) sets three additional
+  ability bits at Physical Levels 50, 60, and 70 for every active party
+  member.
+- AP level (the per-turn AP budget tier) advances at most one step per
+  Result pass, gated by character-specific Physical Level thresholds stored
+  in each character's own `0x20` ability record, up to a shared level-50 +
+  advanced-deathblow-flag gate for the final step (AP level 6 -> 7).
+
+## 8. Character-Specific Exceptions
+
+Three characters have genuinely different rules rather than just different
+stat numbers or growth targets — fully documented in
+[`battle/05` §11](../battle/05-gear-combat-and-special-commands.md#11-character-specific-exceptions):
+
+- **Billy** (command-loadout type 4) can use equipped weapon/ammunition
+  components instead of the ordinary Attack byte for both character and Gear
+  attacks, with his own attack-power normalization formula.
+- **Chu-Chu** (character ID 7) converts character stats directly into her
+  grown-form Gear's HP, engine output, and Defence/Ether-Defence when
+  transformed, rather than using an ordinary Gear record.
+  `BattleResultUpdateType7Stats` (`0x801E3FB0`, see `battle/08` §9) refreshes
+  those persistent seeds after every level-up.
+- **Maria** (command-loadout type 8) has her own separate nine-entry
+  "Controls" ability-threshold table (`BattleResultUpdateType8Unlocks`,
+  `0x801E3EA4`), distinct from the ordinary primary/secondary ability unlock
+  paths every other character uses.
+
+## 9. Chi / Ether Abilities
+
+Every character has access to elemental/Ether-based special techniques under
+its own in-game name (Chi is the internal umbrella term for the command
+category, not a Citan-exclusive move set). The mechanism is already
+documented, just not gathered under that name:
+
+- The resource is MP/EP, the same `+0x4C..0x53` field documented in §3.
+- The damage/healing formula for an Ether-flagged action is the ordinary
+  elemental-scaling and core-subtraction pipeline in
+  [`battle/04` §4](../battle/04-actions-damage-and-status.md#4-damage-pipelines)
+  (`ether = 5 * P - 4 * D`, with elemental weakness/resistance multipliers
+  and elemental-absorption-to-healing).
+- `battle/05` §9 (Ether Machine) confirms the Gear-side Ether command "enters
+  the same ability menu and executor used by the pilot's character
+  abilities," i.e. one shared mechanism for both.
+
+The ability-selection menu itself (`BattleRunChiMenu` and its ~20 supporting
+UI functions) was deliberately not documented — it's UI-drawing plumbing over
+the mechanism above, not a distinct mechanic.
+
+### Ability names
+
+`BattleInitializeChiMenuContents` (`0x80091064`) resolves each ability slot's
+name through `GetSystemTable20String` (`0x80033908`), the same resolved-
+pointer/offset-array mechanism documented for item names in
+[`menu/03` §12](../menu/03-resource-and-string-formats.md#12-item-weapon-and-accessory-name-database) —
+member `20` (byte offset `0x50` in the offset array) of that same 53-member
+item/name database, previously known to hold "character deathblow/Ether
+names" but never cataloged. It decodes to 175 entries in eleven contiguous
+16-slot blocks, one per character:
+
+| Character | Ability names |
+|---|---|
+| Fei | Guided Shot, Inner Healing, Iron Valor, CounterForce, Yang Power, Yin Power, Radiance, Big Bang |
+| Elly | Anemo Bolt, Terra Lance, Thermo Cube, Aqua Ice, Anemo Burn, Terra Storm, Thermo Dragon, Aqua Mist, Anemo Wave, Terra Ghost, Thermo Largo, Aqua Lord |
+| Citan | Sazanami, Renki, Fuuseii, Chiseii, Kaseii, Suiseii, Ryokusho, Reisho, Koga, Yamiga, Senkei |
+| Bart | Wild Smile, Heaven Cent, White Lure, Red Cologne, Blue Cologne, White Cologne, Wind Mode, Earth Mode, Fire Mode, Water Mode |
+| Billy | Purity Light, Healing Light, Holy Light, Goddess Call, Goddess Eyes, Wind Shield, Earth Shield, Fire Shield, Water Shield, Goddess Wake |
+| Rico | Steel Fist, Steel Body, Steel Spirit, Steel Mettle |
+| Emeralda | Anemo Dharm, Terra Feist, Thermo Gord, Aqua Aroum, Anemo Omega, Terra Holz, Thermo Giest, Aqua Dhaum |
+| Chu-Chu | Forest Dance, Culen Prayer, Myrm Prayer, Play Dead, Maiden Kiss, Forest Wind, Earth Gnome, Ancient Myth |
+| Maria | Robo Beam, Robo Missile, Robo Punch, Robo Kick, Graviton Gun |
+| Citan (2) | Identical block to Citan (byte-for-byte) |
+| Emeralda (2) | Identical block to Emeralda (byte-for-byte) |
+
+The block-to-character assignment above rests on two independent structural
+proofs, not just thematic reading: the Citan/Citan (2) blocks and the
+Emeralda/Emeralda (2) blocks are each byte-for-byte identical pairs, exactly
+matching the roster's own two duplicate character slots (§2) — a coincidence
+this exact would not happen by chance. The other nine blocks' assignment to
+a specific character is a strong thematic match (elemental progressions for
+Elly, holy/healing names for Billy, mascot-themed names for Chu-Chu, and so
+on) rather than something read directly out of the selector code, since that
+selector table lives in a runtime-allocated region (see below) that couldn't
+be statically resolved. Treat the Fei, Bart, and Maria assignments in
+particular as the least independently confirmed of the eleven.
+
+EP costs and effects were not found. `BattleLoadChiMenuData`'s selector bytes
+and per-slot cost/element data resolve to addresses roughly 37 KB past the
+end of the statically-loaded `battle-overlay` image — a heap/BSS region
+allocated at runtime whose base address isn't fixed at link time, so it
+can't be read from the static disc/overlay data the way the name table
+above could. Getting actual EP-cost numbers would need either a live trace
+of that heap allocation or a lucky independent discovery of the same data
+elsewhere.
+
+## 10. Not Yet Extracted: Per-Character Growth Targets, Ability Costs And Effects
+
+Two data tables implied by the mechanisms above remain incomplete:
+
+1. **Per-character (per-command-loadout-type) growth targets** — the actual
+   below/above-level-99 target values in each `0x110`-byte growth record
+   (§6), which would let someone answer "what's Fei's HP at level 99" rather
+   than only "here's the formula that computes it." The consumer-side
+   arithmetic is fully confirmed at the instruction level: resident pointer
+   `0x800D2C08` (itself resolved from a chain rooted at `0x801E44C8` =
+   `0x800CCCE8`, the documented live-entity base) holds `table_base`, and
+   `BattleResultApplyPhysicalLevelStatGrowth`/`...EtherLevelStatGrowth` read
+   `table_base + type*0x110 + level_band + field_offset`. `0x800D2C08` loads
+   from an LZSS-compressed member inside the archive selected by
+   `ArchiveSetIndex(0x10, 2)`. Extraction stalls one level deeper: the size
+   the loader allocates for that read comes from `ArchiveDecodeSize`
+   (`0x80028738`), which — on the retail CD path (confirmed; the alternate
+   branch only runs under a PsyQ host-PC dev-kit link via `PCopen`/`PCclose`/
+   `PClseek`, never in the shipped game) — computes its result from two
+   further resident lookup bases (`0x8005FE14`, and `0x8005FDF0` via the
+   neighboring size-decoder) that are themselves populated from disc-loaded
+   filesystem metadata nobody has reverse-engineered yet. Getting real values
+   out would mean reversing that metadata format first — a standalone
+   investigation on the scale of the field-ID or item-database addressing
+   work already done elsewhere in this project, not a quick follow-up.
+   Deliberately not pursued further; the formula above is the verified
+   stopping point.
+2. **Chi/Ether ability EP costs and effects** — names are done (above); costs
+   and effects were traced to a runtime-allocated heap region whose base
+   address isn't fixed at link time, so they can't be read from static disc
+   data the way the name table could. Would need a live runtime trace, not
+   more static analysis.
+
+## 11. Party Formation And Availability
+
+Full derivation: [`menu/08`](../menu/08-member-change-and-party-formation.md).
+
+Three active party slots and eleven playable character IDs (`0..10`) are the
+complete formation state. A character's availability comes from a bitmask
+test (`menu/08` §5):
+
+```text
+available_mask = (game_state+0x1D30 & game_state+0x1D32) & 0x07FF
+```
+
+masked to eleven bits, one per character ID. Member Change filters the three
+persistent active-party bytes against this mask on entry (an unavailable
+character's slot becomes empty, `0xFF`) and rebuilds the bench list by
+walking IDs `0..10` in order, admitting any available ID not already active.
+
+## 12. Persistence
+
+Full derivation: [`battle/08` §11](../battle/08-results-progression-and-persistence.md#11-character-defeat-and-gear-persistence).
+
+After Result processing (or a successful escape), each represented
+character's live Battle state writes back to its persistent record:
+
+- Current HP and MP copy from live state, clamped to the (possibly just
+  grown) persistent maxima.
+- The seven deathblow-proficiency counters and the prevariance
+  lethal-match counter copy from live state.
+- A defeated or removed character persists at exactly one HP, not zero.
+- Chu-Chu's grown-form Gear HP converts back to character HP as
+  `max(1, floor((gear_hp + 1) / 50))` before the ordinary HP copy.
+
+Associated Gear state persists independently in the same pass (current HP
+and fuel, clamped to maxima, with a destroyed Gear returning at ten percent
+of maximum HP) — see `battle/08` §11 for the Gear-ID range and exact rules.

--- a/docs/xenogears/characters/README.md
+++ b/docs/xenogears/characters/README.md
@@ -1,0 +1,27 @@
+# Xenogears Characters
+
+This folder is a cross-cutting reference: it pulls together everything already
+documented about the eleven playable characters — their stat records,
+experience and growth, deathblow and ability unlocks, party formation, and
+persistence — from wherever it actually lives (mostly `battle/03`, `battle/05`,
+`battle/08`, and `menu/06`/`menu/08`). It does not restate those chapters'
+full derivations; it indexes and connects them the way
+[`docs/xenogears/rng/`](../rng/README.md) indexes RNG rolls without
+re-deriving battle formulas.
+
+## Reading Order
+
+1. [`01-characters.md`](01-characters.md) is the only chapter so far: the
+   eleven-character roster, the shared stat record, equipment and displayed
+   stats, experience and leveling, stat growth, deathblows and ability
+   unlocks, the three character-specific exceptions (Billy, Chu-Chu, Maria),
+   party formation and availability, and persistence.
+
+## Scope
+
+This folder covers characters specifically — not Gears (see `battle/05` and
+`menu/06`/`menu/11` for Gear stats and tuning), not enemies (see `battle/06`
+and `rng/04`), and not the Chi/Ether ability *menu* itself (that's UI
+plumbing over the same ability system described here; see `battle/05` §9 and
+`battle/08` §9 for what exists already — the menu's own drawing code was
+deliberately left undocumented as low mod-relevance).

--- a/docs/xenogears/menu/03-resource-and-string-formats.md
+++ b/docs/xenogears/menu/03-resource-and-string-formats.md
@@ -278,11 +278,13 @@ drop classes sit at these fixed byte offsets into the member-offset array
 | 3 | Gear part | `0xC8` | 104 |
 | 4 | Gear weapon | `0xCC` | 99 |
 
-The same member array holds several other bundles not tied to a drop class —
-character deathblow/Ether names (`Guided Shot`, `Inner Healing`, ...) at
-offsets `0x00`-`0x28`ish and `0x50`/`0xC0`, and Gear special-attack names
-(`Fix Frame HP`, `Ygg Cannon`, ...) at `0xD0` — which this chapter does not
-otherwise use and leaves uncatalogued.
+The same member array holds several other bundles not tied to a drop class.
+Member `20` (offset `0x50`) holds the Chi/Ether ability names for all eleven
+characters, cataloged in
+[`characters/01` §9](../characters/01-characters.md#9-chi-ether-abilities).
+Character deathblow names at offsets `0x00`-`0x28`ish and `0xC0`, and Gear
+special-attack names (`Fix Frame HP`, `Ygg Cannon`, ...) at `0xD0`, remain
+uncatalogued — this chapter does not otherwise use them.
 `tools/xenogears_text.py`'s `read_item_name_bundle` implements the five
 drop-class lookups above; it is the reference implementation used by
 [`rng/04-enemy-drop-tables.md`](../rng/04-enemy-drop-tables.md).

--- a/docs/xenogears/menu/11-gear-shop-tuning-and-preview.md
+++ b/docs/xenogears/menu/11-gear-shop-tuning-and-preview.md
@@ -549,6 +549,14 @@ slot 1 before replacing its wrapper contents.
 
 ## 25. Function Index
 
+`GearShopMenuGetRandomRangeValue` (`801C511C`) is a correctly-implemented
+range-roll helper with no discoverable caller anywhere in this overlay or the
+rest of the recompiled game — no direct call, no computed call, and no
+reference to its address as data in this overlay's raw binary. Nothing in
+this chapter's tuning or preview flow appears to actually use it; treat it as
+dead code in the retail build rather than a live source of randomness. See
+[`rng/01` §2.4](../rng/01-generators-and-determinism.md#24-consumers-across-modules).
+
 ```text
 801C511C GearShopMenuGetRandomRangeValue | 801C51B8 GearShopMenuSetFt4Rect | 801C5228 GearShopMenuIsCharacterFlagSet | 801C5244 GearShopMenuGetCharacterBitMask | 801C5260 GearShopMenuGetGearEquipFlags | 801C527C GearShopMenuGearCanEquip | 801C5298 GearShopMenuParseNumberToString | 801C5344 GearShopMenuManageResourceState
 801C53A8 GearShopMenuManageCoreState | 801C540C GearShopSelectionMenuManager | 801C5470 GearShopMenuManageTextBatchState | 801C54D4 GearShopMenuDressingRoomManager | 801C5538 GearShopMenuManageOverlayPacketState | 801C559C GearShopMenuManageExtendedDisplayState | 801C5600 GearShopMenuShopManager | 801C5664 GearShopMenuManagePreviewState

--- a/docs/xenogears/rng/01-generators-and-determinism.md
+++ b/docs/xenogears/rng/01-generators-and-determinism.md
@@ -98,11 +98,24 @@ survey:
   random turns, and the `RandVariable`/`MulVariableWithRand` Field script
   opcodes.
 - World Map: `WorldMapSelectRandomEncounter` and the warp/shake camera tasks.
-- Menus and shops: `GearShopMenuGetRandomRangeValue`-backed rolls in the Gear
-  shop tuning flow.
+- Menus and shops: `GearShopMenuGetRandomRangeValue` (`0x801C511C`) is a real,
+  correctly-implemented range-roll helper, but exhaustive static analysis
+  found no caller for it anywhere — no direct call in any shard or overlay,
+  no computed/indirect call within its own overlay, and no reference to its
+  address in that overlay's raw binary as data. It appears to be dead code in
+  the retail build rather than an active consumer of this stream; see
+  [`menu/11`](../menu/11-gear-shop-tuning-and-preview.md#25-function-index) for
+  where it's cataloged.
 - Battling (the colosseum minigame) draws on the same `rand` for camera
   placement, particle jitter, and COM AI tactical randomization, all through
-  its own overlay-local wrapper calls.
+  its own overlay-local wrapper calls; the gameplay-affecting rolls are
+  indexed in [`06-battling-rng.md`](06-battling-rng.md).
+- The resident sprite animation VM shared by Field, Battle, and other
+  sprite-driven modules has five dedicated random opcodes (`AC`, `C0`, `C1`,
+  `C4`, `E5` — random angular/radial displacement, random position, and
+  assign-random-below-immediate); see
+  [`graphics/04` §10](../graphics/04-models-sprites-and-animation.md#10-sprite-animation-vm)
+  for the full opcode catalog.
 
 This list characterizes the stream's reach; it is not an exhaustive per-site
 catalog of every roll and its exact formula (drop tables, individual

--- a/docs/xenogears/rng/06-battling-rng.md
+++ b/docs/xenogears/rng/06-battling-rng.md
@@ -1,0 +1,80 @@
+# Battling RNG
+
+## 1. Scope
+
+This chapter indexes every explicit random roll in Battling, the colosseum
+Gear-fighting minigame, from the generator's side: what each roll consumes,
+and where its formula is already documented in full. All rolls in this
+chapter draw from the shared gameplay generator described in
+[`01-generators-and-determinism.md`](01-generators-and-determinism.md),
+through Battling's own overlay-local `rand` wrapper calls. None of them touch
+the Movie or sound-modulator generators.
+
+Every formula in this chapter is quoted from, not re-derived from, the cited
+`battling/` chapter; this document does not restate their surrounding
+context. Purely cosmetic rolls (camera placement, particle jitter, projectile
+trail effects, victory-camera orbit, replay-camera orbit, ambient sound
+variety) are deliberately not indexed here — they don't affect a bout's
+outcome and are covered by the blanket mention in
+[`01` §2.4](01-generators-and-determinism.md#24-consumers-across-modules).
+
+## 2. Tactical Randomization
+
+| Roll | Formula | Source |
+|---|---|---|
+| Tactical flag randomization | Compares fresh random bytes against four tuning weights to set bits `0x0100`/`0x0200`/`0x0400`/`0x0800`, randomly picks orientation bit `0x1000`, and stores a random low byte in the packed halfword | [`battling/06` §3](../battling/06-ai-practice-and-rubber-band.md#3-com-state-layout) (`BattlingAiTacticalFlagsRandomize`, `0x8008F7B8`) |
+| Attack approval | Weighted comparison combining tuning weights, heat state, and both fighters' HP; random comparisons use the low byte of the random value | [`battling/06` §6](../battling/06-ai-practice-and-rubber-band.md#6-attack-approval-probabilities) (`BattlingAiAttackDecisionEvaluate`, `0x8008F5B4`) |
+| Engagement approval | Distance-gated random test against `decision_weight_0`, or against `decision_weight_3` when Heat risk is high | [`battling/06` §6](../battling/06-ai-practice-and-rubber-band.md#6-attack-approval-probabilities) (`BattlingAiEngagementDecisionEvaluate`, `0x8008F720`) |
+| Terrain-dependent action suppression | On a terrain-class-1 opponent, `random_mod_4 != 0` (75%) suppresses the whole call; otherwise a jump and/or special-action command is queued | [`battling/06` §5.6](../battling/06-ai-practice-and-rubber-band.md#56-terrain-dependent-action-gate) (`BattlingAiQueueTerrainDependentActions`, `0x8008F900`) |
+
+## 3. State Machine Rolls
+
+| Roll | Formula | Source |
+|---|---|---|
+| Attack cadence refresh | `burst_delay = (2 - difficulty) * 20 + random(0..19) + 1` | [`battling/06` §4](../battling/06-ai-practice-and-rubber-band.md#4-difficulty) (`BattlingAiBasicBurstRefresh`, `0x8008FF24`) |
+| Initial/refreshed basic burst | `random_mod_10` picks a burst count of 1 (20%), 2 (30%), or 3 (50%); each queued action is `random_mod_2 + 1` | [`battling/06` §5.3](../battling/06-ai-practice-and-rubber-band.md#53-attack-state) (`BattlingAiRandomBasicBurstQueue`, `0x8008FE80`) |
+| Attack-state transition roll | Ten weighted random branches select Retreat, Idle, queuing a burst/special, or Approach | [`battling/06` §5.3](../battling/06-ai-practice-and-rubber-band.md#53-attack-state) |
+| Approach random heading | Closes distance with a randomized heading around `-0x300` | [`battling/06` §5.4](../battling/06-ai-practice-and-rubber-band.md#54-approach-state) |
+| Approach extra-burst permission (Hard) | `random_byte < decision_weight_1` | [`battling/06` §5.4](../battling/06-ai-practice-and-rubber-band.md#54-approach-state) |
+| Retreat entry | `target_distance = random(0..0x5FF) + 0x100`; `repetitions = random(0..4) + 3` | [`battling/06` §5.5](../battling/06-ai-practice-and-rubber-band.md#55-retreat-state) (`BattlingComAiRetreatStateEnter`, `0x80090894`) |
+
+## 4. Practice Behaviors
+
+| Roll | Formula | Source |
+|---|---|---|
+| RUN AWAY heading and timer | `heading = random(0..1535) + 1280`; `countdown = random(0..49) + 10` | [`battling/06` §8.1](../battling/06-ai-practice-and-rubber-band.md#81-give-chase-and-run-away) (`BattlingPracticeNearRangeMovementUpdate`, `0x8008F094`) |
+| GIVE CHASE heading and timer | `heading = random(0..1535) - 768`; `countdown = random(0..119) + 10` | [`battling/06` §8.1](../battling/06-ai-practice-and-rubber-band.md#81-give-chase-and-run-away) (`BattlingPracticeFarRangeMovementUpdate`, `0x8008F17C`) |
+| UP AND AT'EM / SLOWPOKE burst queue | Same `random_mod_10` burst-count draw as §3's basic burst, plus a short/long delay choice | [`battling/06` §8](../battling/06-ai-practice-and-rubber-band.md#8-practice-behaviors) (`BattlingPracticeRandomBasicActionsQueue`, `0x8008EF30`) |
+
+## 5. Scripted-Scenario Climax
+
+| Roll | Formula | Source |
+|---|---|---|
+| Attachment-point emitter rearm | Rearms after `8..23` updates; emits effect `9` on odd timer values, with additional random passes emitting effects `0x0B` and `8` | [`battling/06` §10](../battling/06-ai-practice-and-rubber-band.md#10-scripted-scenario-climax) (`BattlingUpdateScriptedScenarioClimax`, `0x80072170`) |
+
+## 6. Not Indexed: Confirmed Non-Random
+
+`BattlingStartRandomArenaReentryMotion` (`0x80070FD8`) — despite its name and
+despite `battling/08`'s opcode table previously calling its result a
+"randomized inward heading" — contains no call to `rand` or any wrapper. It
+picks between two geometrically computed headings (`ratan2` toward the arena
+center, or a shared side-to-side heading global) based on a fixed threshold.
+See [`battling/08` §4](../battling/08-tutorial-and-attract-scripts.md#4-wait-and-movement-operations)
+for the corrected description.
+
+## 7. Function Index
+
+| Address | Function |
+|---|---|
+| `0x8008F5B4` | `BattlingAiAttackDecisionEvaluate` |
+| `0x8008F720` | `BattlingAiEngagementDecisionEvaluate` |
+| `0x8008F7B8` | `BattlingAiTacticalFlagsRandomize` |
+| `0x8008F900` | `BattlingAiQueueTerrainDependentActions` |
+| `0x8008FE80` | `BattlingAiRandomBasicBurstQueue` |
+| `0x8008FF24` | `BattlingAiBasicBurstRefresh` |
+| `0x80090894` | `BattlingComAiRetreatStateEnter` |
+| `0x8008F094` | `BattlingPracticeNearRangeMovementUpdate` |
+| `0x8008F17C` | `BattlingPracticeFarRangeMovementUpdate` |
+| `0x8008EF30` | `BattlingPracticeRandomBasicActionsQueue` |
+| `0x80072170` | `BattlingUpdateScriptedScenarioClimax` |
+| `0x80070FD8` | `BattlingStartRandomArenaReentryMotion` (non-random, see §6) |

--- a/docs/xenogears/rng/README.md
+++ b/docs/xenogears/rng/README.md
@@ -27,6 +27,9 @@ folder documents those generators and the data they feed.
    [`field/11`](../field/11-encounters-transitions-loading-and-persistence.md),
    covering all 635 fields (of 730) that carry an encounter table, deduplicated
    down to the 55 tables actually authored.
+6. [`06-battling-rng.md`](06-battling-rng.md) indexes every explicit random
+   roll in Battling, the colosseum minigame, cross-referencing the formula
+   already documented in each `battling/` chapter rather than restating it.
 
 ## Conventions
 


### PR DESCRIPTION
Fills in the Battling colosseum's AI system where the existing chapter had gaps — a terrain-based suppression gate on queued actions, the actual odds behind its basic-attack burst queue, and the heading/timer formulas for the two practice-mode movement behaviors — and corrects one function, `BattlingStartRandomArenaReentryMotion`, that reads as random from its name but calls no RNG at all.

Adds `rng/06-battling-rng.md`, indexing Battling's rolls the same way the existing Battle chapter indexes its own. Tracing every consumer for that index turned up `GearShopMenuGetRandomRangeValue` as dead code — a real, correctly-implemented function with no caller anywhere in the recompiled game — which corrects an earlier claim that it backs live Gear shop rolls.

Adds a new `characters/` aspect folder gathering what was scattered across `battle/` and `menu/`: the shared stat record, EXP and growth formulas, deathblow and ability unlocks, and the Billy/Chu-Chu/Maria exceptions, plus a newly-extracted table of Chi/Ether ability names for all eleven characters, cross-verified against the game's own duplicate character records rather than guessed from theme.