### PR TITLE
Fix native Windows/MSVC build (closes #7)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -38,7 +38,12 @@ param(
     [int]$BuildJobs = 0
 )
 
-$ErrorActionPreference = "Stop"
+# NOT "Stop": every step below is a native exe (cmake/ninja/psxrecomp-*)
+# checked via an explicit $LASTEXITCODE test below it. Under "Stop",
+# PowerShell 5.1 promotes the *first line* a native tool writes to stderr
+# (even routine CMake/ninja status text, with exit code 0) into a
+# terminating NativeCommandError, aborting the script on false positives.
+$ErrorActionPreference = "Continue"
 
 if ($BuildJobs -le 0) {
     $ConfiguredBuildJobs = if ($env:BUILD_JOBS) {
@@ -189,9 +194,9 @@ $MANIFEST_IDENTITY_SHA256 = $MANIFEST_METADATA.manifest_identity
 # --- Step 1: Build the recompiler ---
 Write-Host "==> Building recompiler..."
 & cmake -S $RECOMPILER_DIR -B $RECOMPILER_BUILD @CMakeGeneratorArgs `
-    -DCMAKE_BUILD_TYPE=Release `
-    -DPSX_GAME_EXTRA_IDENTITY_SHA256=$GAME_IDENTITY_SHA256 `
-    -DPSX_GAME_MANIFEST_DIGEST_SHA256=$MANIFEST_IDENTITY_SHA256
+    "-DCMAKE_BUILD_TYPE=Release" `
+    "-DPSX_GAME_EXTRA_IDENTITY_SHA256=$GAME_IDENTITY_SHA256" `
+    "-DPSX_GAME_MANIFEST_DIGEST_SHA256=$MANIFEST_IDENTITY_SHA256"
 if ($LASTEXITCODE -ne 0) { throw "Recompiler configuration failed" }
 & cmake --build $RECOMPILER_BUILD --config Release --parallel $BuildJobs
 if ($LASTEXITCODE -ne 0) { throw "Recompiler build failed" }

--- a/native_renderer/CMakeLists.txt
+++ b/native_renderer/CMakeLists.txt
@@ -9,6 +9,19 @@ set(XG_RENDER_PRIVATE_INCLUDE_DIRS
     src/producers/world
     src/runtime)
 
+if(MSVC)
+    # xg_render_auth_runtime.c / xg_render_instrumentation.c use <stdatomic.h>
+    # (atomic_flag); MSVC only supports it under the experimental C11 atomics
+    # switch (same scoping psxrecomp/runtime/runtime.cmake uses for
+    # audio_trace.c). Source-file scoped so it reaches every target that
+    # compiles these two files (the xg_render_auth library and the
+    # test_xg_render_static_auth test executable alike).
+    set_property(SOURCE
+        src/runtime/xg_render_auth_runtime.c
+        src/infrastructure/xg_render_instrumentation.c
+        APPEND PROPERTY COMPILE_OPTIONS /experimental:c11atomics)
+endif()
+
 add_library(xg_visual_state STATIC src/core/xg_visual_state.c)
 target_include_directories(xg_visual_state PUBLIC include)
 target_compile_features(xg_visual_state PUBLIC c_std_11)


### PR DESCRIPTION
Fixes #7 — building with `build.ps1 -Generator "Visual Studio 17 2022"` on native Windows.

- `build.ps1`: two PowerShell 5.1 bugs (`$ErrorActionPreference = "Stop"` treating routine stderr output as fatal, and unquoted cmake args not expanding reliably) that block a fresh Windows clone before the compiler is even reached.
- `native_renderer/CMakeLists.txt`: two files use `<stdatomic.h>`, which needs `/experimental:c11atomics` under MSVC.
- Bumps the `psxrecomp` submodule to a companion branch with 8 more fixes (GNU-extension replacements, a linking gap, a linkage bug, and a startup crash) — see OpokXeno/psxrecomp#6.

Verified with a full native MSVC build: recompiler, runtime, and the game itself boot and run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)