### PR TITLE
docs: recommend .cue+.bin/.chd for disc images

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Grab the x86-64 archive for your platform from [Releases](https://github.com/Opo
 2. **Optional: select a retail BIOS** — OpenBIOS runs by default. To use the retail backend, select your legally obtained matching `SCPH1001.BIN` (a 512 KB file dumped from your own console) via Settings → System → Browse.
 3. Optionally adjust renderer, supersampling, screen look, widescreen, and controller settings, then press **Launch**. Your choices are remembered.
 
-**Accepted disc formats:** `.cue` + `.bin` (preferred — pick the `.cue`), direct
-`.bin`, `.img`, `.iso`, `.car`, and `.chd`. If the header or game ID does not
-match SLUS-00664, the launcher warns and tries to run the image anyway.
+**Accepted disc formats:** `.cue` + `.bin` and `.chd`. If the header or game ID
+does not match SLUS-00664, the launcher warns and tries to run the image
+anyway.
 
 Official Linux and Windows releases are 64-bit x86-64 builds with SDL3 linked
 statically; no separate SDL installation is required.


### PR DESCRIPTION
Related to #3 — cutscene/CD audio missing with plain `.iso`/`.img` images. That's a data limitation of those formats (the audio data isn't in the file, not an emulation bug), so instead of a runtime warning, this just points the README's disc format guidance at `.cue`+`.bin` and `.chd`.